### PR TITLE
CLI without ArgumentParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Un-released changes (main)
 
+* Reduce size of Tuist plugin archive to less than a third of before.
+
 ## v0.0.1
 
 * Initial release of SwiftHooks

--- a/Package.resolved
+++ b/Package.resolved
@@ -8,15 +8,6 @@
         "revision" : "d273b5b7025d386feef79ef6bad7de762e106eaf",
         "version" : "4.2.0"
       }
-    },
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
-      "state" : {
-        "revision" : "df9ee6676cd5b3bf5b330ec7568a5644f547201b",
-        "version" : "1.1.3"
-      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -16,15 +16,13 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-argument-parser", exact: "1.1.3"),
         .package(url: "https://github.com/JohnSundell/Files", exact: "4.2.0"),
     ],
     targets: [
         .executableTarget(
             name: "SwiftHooksCLI",
             dependencies: [
-                .target(name: "SwiftHooksKit"),
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .target(name: "SwiftHooksKit")
             ]
         ),
         .target(

--- a/Sources/SwiftHooksCLI/InstallCommand.swift
+++ b/Sources/SwiftHooksCLI/InstallCommand.swift
@@ -1,22 +1,56 @@
 // Copyright © 2022 Andrew Lord.
 
-import ArgumentParser
 import SwiftHooksKit
 
-struct InstallCommand: ParsableCommand {
-    static var configuration = CommandConfiguration(
-        commandName: "install",
-        abstract: "Install shared Git hooks"
-    )
+struct InstallCommand {
+    let programName: String
+    let option: String?
 
-    @Flag(name: .shortAndLong, help: "Silence any output except errors")
-    var quiet: Bool = false
-
-    func run() throws {
-        SwiftHooks.configuration.printer = ConsolePrinter(quiet: quiet)
-        try runCommand {
-            try InstallHooksService()
-                .run()
+    func run() {
+        switch option {
+        case .none:
+            performInstall(isQuiet: false)
+        case .some("-q"), .some("--quiet"):
+            performInstall(isQuiet: true)
+        case .some("-h"), .some("--help"):
+            printHelp()
+        case let .some(other):
+            printUnexpectedOptionError(option: other)
         }
+    }
+
+    private func performInstall(isQuiet: Bool) {
+        SwiftHooks.configuration.printer = ConsolePrinter(quiet: isQuiet)
+        runCommand {
+            try InstallHooksService().run()
+        }
+    }
+
+    private func printUnexpectedOptionError(option: String) {
+        let message = """
+        Error: Unknown option '\(option)'
+
+        USAGE: \(programName) install [--quiet]
+
+        OPTIONS:
+          -q, --quiet             Silence any output except errors
+          -h, --help              Show help information.
+
+        """
+        print(message)
+    }
+
+    private func printHelp() {
+        let help = """
+        OVERVIEW: Install shared Git hooks
+
+        USAGE: \(programName) install [--quiet]
+
+        OPTIONS:
+          -q, --quiet             Silence any output except errors
+          -h, --help              Show help information.
+        
+        """
+        print(help)
     }
 }

--- a/Sources/SwiftHooksCLI/MainCommand.swift
+++ b/Sources/SwiftHooksCLI/MainCommand.swift
@@ -1,11 +1,88 @@
 // Copyright © 2022 Andrew Lord.
 
-import ArgumentParser
+import Darwin
+import Foundation
 
-struct MainCommand: ParsableCommand {
-    static var configuration = CommandConfiguration(
-        commandName: "hooks",
-        abstract: "",
-        subcommands: [InstallCommand.self, UninstallCommand.self, VersionCommand.self]
-    )
+struct MainCommand {
+    func run() {
+        let programName = extractProgramName()
+        let (subcommand, option) = extractSubcommand(programName: programName)
+        switch subcommand {
+        case "install":
+            InstallCommand(programName: programName, option: option).run()
+        case "uninstall":
+            UninstallCommand(programName: programName, option: option).run()
+        case "version":
+            VersionCommand(programName: programName, option: option).run()
+        case "-h", "--help":
+            printHelp(programName: programName)
+        default:
+            printUnexpectedArgumentError(programName: programName, argument: subcommand)
+        }
+    }
+
+    private func extractProgramName() -> String {
+        guard let program = CommandLine.arguments.first else {
+            exit(EXIT_SUCCESS)
+        }
+        var programName = URL(fileURLWithPath: program).lastPathComponent
+        if programName == "tuist-hooks" {
+            programName = "tuist hooks"
+        }
+        return programName
+    }
+
+    private func extractSubcommand(programName: String) -> (subcommand: String, option: String?) {
+        let arguments = Array(CommandLine.arguments.dropFirst())
+        guard arguments.count > 0 else {
+            printHelp(programName: programName)
+            exit(EXIT_SUCCESS)
+        }
+        guard arguments.count <= 2, let command = arguments.first else {
+            printHelp(programName: programName)
+            exit(EXIT_FAILURE)
+        }
+        if arguments.count == 1 {
+            return (subcommand: command, option: nil)
+        }
+        return (subcommand: command, option: arguments.last)
+    }
+
+    private func printUnexpectedArgumentError(programName: String, argument: String) {
+        let message = """
+        Error: Unknown argument '\(argument)'
+
+        USAGE: \(programName) <subcommand>
+
+        OPTIONS:
+          -h, --help              Show help information.
+
+        SUBCOMMANDS:
+          install                 Install shared Git hooks
+          uninstall               Uninstall shared Git hooks
+          version                 Print version
+
+        See '\(programName) <subcommand> --help' for detailed help.
+
+        """
+        print(message)
+    }
+
+    private func printHelp(programName: String) {
+        let help = """
+        USAGE: \(programName) <subcommand>
+
+        OPTIONS:
+          -h, --help              Show help information.
+
+        SUBCOMMANDS:
+          install                 Install shared Git hooks
+          uninstall               Uninstall shared Git hooks
+          version                 Print version
+
+        See '\(programName) <subcommand> --help' for detailed help.
+
+        """
+        print(help)
+    }
 }

--- a/Sources/SwiftHooksCLI/RunCommand.swift
+++ b/Sources/SwiftHooksCLI/RunCommand.swift
@@ -1,14 +1,15 @@
 // Copyright © 2022 Andrew Lord.
 
-import ArgumentParser
+import Darwin
 import SwiftHooksKit
 
-extension ParsableCommand {
-    func runCommand(runCommand: () throws -> Void) throws {
-        do {
-            try runCommand()
-        } catch ExecutionError.failure {
-            throw ExitCode.failure
-        }
+func runCommand(runCommand: () throws -> Void) {
+    do {
+        try runCommand()
+    } catch ExecutionError.failure {
+        exit(EXIT_FAILURE)
+    } catch {
+        print(error)
+        exit(EXIT_FAILURE)
     }
 }

--- a/Sources/SwiftHooksCLI/UninstallCommand.swift
+++ b/Sources/SwiftHooksCLI/UninstallCommand.swift
@@ -1,22 +1,56 @@
 // Copyright © 2022 Andrew Lord.
 
-import ArgumentParser
 import SwiftHooksKit
 
-struct UninstallCommand: ParsableCommand {
-    static var configuration = CommandConfiguration(
-        commandName: "uninstall",
-        abstract: "Uninstall shared Git hooks"
-    )
+struct UninstallCommand {
+    let programName: String
+    let option: String?
 
-    @Flag(name: .shortAndLong, help: "Silence any output except errors")
-    var quiet: Bool = false
-
-    func run() throws {
-        SwiftHooks.configuration.printer = ConsolePrinter(quiet: quiet)
-        try runCommand {
-            try UninstallHooksService()
-                .run()
+    func run() {
+        switch option {
+        case .none:
+            performUninstall(isQuiet: false)
+        case .some("-q"), .some("--quiet"):
+            performUninstall(isQuiet: true)
+        case .some("-h"), .some("--help"):
+            printHelp()
+        case let .some(other):
+            printUnexpectedOptionError(option: other)
         }
+    }
+
+    private func performUninstall(isQuiet: Bool) {
+        SwiftHooks.configuration.printer = ConsolePrinter(quiet: isQuiet)
+        runCommand {
+            try UninstallHooksService().run()
+        }
+    }
+
+    private func printUnexpectedOptionError(option: String) {
+        let message = """
+        Error: Unknown option '\(option)'
+
+        USAGE: \(programName) uninstall [--quiet]
+
+        OPTIONS:
+          -q, --quiet             Silence any output except errors
+          -h, --help              Show help information.
+
+        """
+        print(message)
+    }
+
+    private func printHelp() {
+        let help = """
+        OVERVIEW: Uninstall shared Git hooks
+
+        USAGE: \(programName) uninstall [--quiet]
+
+        OPTIONS:
+          -q, --quiet             Silence any output except errors
+          -h, --help              Show help information.
+        
+        """
+        print(help)
     }
 }

--- a/Sources/SwiftHooksCLI/VersionCommand.swift
+++ b/Sources/SwiftHooksCLI/VersionCommand.swift
@@ -1,17 +1,50 @@
 // Copyright © 2022 Andrew Lord.
 
-import ArgumentParser
 import SwiftHooksKit
 
-struct VersionCommand: ParsableCommand {
-    static var configuration = CommandConfiguration(
-        commandName: "version",
-        abstract: "Print version"
-    )
+struct VersionCommand {
+    let programName: String
+    let option: String?
 
-    func run() throws {
+    func run() {
+        switch option {
+        case .none:
+            performVersion()
+        case .some("-h"), .some("--help"):
+            printHelp()
+        case let .some(other):
+            printUnexpectedOptionError(option: other)
+        }
+    }
+
+    private func performVersion() {
         SwiftHooks.configuration.printer = ConsolePrinter(quiet: false)
-        VersionService()
-            .run()
+        VersionService().run()
+    }
+
+    private func printUnexpectedOptionError(option: String) {
+        let message = """
+        Error: Unknown option '\(option)'
+
+        USAGE: \(programName) version
+
+        OPTIONS:
+          -h, --help              Show help information.
+
+        """
+        print(message)
+    }
+
+    private func printHelp() {
+        let help = """
+        OVERVIEW: Print version
+
+        USAGE: \(programName) version
+
+        OPTIONS:
+          -h, --help              Show help information.
+        
+        """
+        print(help)
     }
 }

--- a/Sources/SwiftHooksCLI/main.swift
+++ b/Sources/SwiftHooksCLI/main.swift
@@ -1,5 +1,3 @@
 // Copyright © 2022 Andrew Lord.
 
-import Foundation
-
-MainCommand.main()
+MainCommand().run()


### PR DESCRIPTION
<!-- Thanks for your contribution to *SwiftHooks*! Please check the boxes below before opening the pull request, you do this by putting an x in the box like this: [x]. Thank you! -->

### Checklist

- [X] I've read the [guide for contributing](https://github.com/lordcodes/swifthooks/blob/master/CONTRIBUTING.md).
- [X] I've checked there are no other [open pull requests](https://github.com/lordcodes/swifthooks/pulls) for the same change.
- [X] I've updated documentation if needed.
- [X] I've tested all changes are working as intended.

### Reason for change
<!-- If the pull request fixes an open issue, please include a link to the issue here. -->
<!-- Please explain why the change is required and the problem it solves. -->
The ArgumentParser dependency increases the Tuist plugin archive from 740KB to ~3MB, as it is simple to parse a few commands/options without it, may as well to reduce download size.

### Description
<!-- Please describe the changes you have made, providing as much detail as possible and including how the changes were tested. -->
Parse sub-commands and options without ArgumentParser, show help for top-level and for each sub-command.
